### PR TITLE
Add GSAP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Welcome to my portfolio website! This site is crafted to showcase my skills, pro
 - **Tailwind CSS**: A utility-first CSS framework for rapid and custom UI design.
 - **React.js**: A library for building interactive UIs.
 - **Three.js**: A JavaScript library for creating and displaying animated 3D graphics in the browser.
+- **GSAP**: A robust animation library used here for smooth page transitions.
 
 ## 🌟 Features
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -3,6 +3,7 @@ import { FaLocationArrow } from "react-icons/fa6";
 import MagicButton from "./MagicButton";
 import { Spotlight } from "./ui/Spotlight";
 import { TextGenerateEffect } from "./ui/TextGenerateEffect";
+import GsapFadeIn from "./ui/GsapFadeIn";
 
 const Hero = () => {
   return (
@@ -41,7 +42,7 @@ const Hero = () => {
       </div>
 
       <div className="flex justify-center relative my-20 z-10">
-        <div className="max-w-[89vw] md:max-w-2xl lg:max-w-[60vw] flex flex-col items-center justify-center">
+        <GsapFadeIn className="max-w-[89vw] md:max-w-2xl lg:max-w-[60vw] flex flex-col items-center justify-center">
           <p className="uppercase tracking-widest text-xs text-center text-blue-100 max-w-80">
             {/* Dynamic Web Magic with Next.js */}
           </p>
@@ -67,7 +68,7 @@ const Hero = () => {
               position="right"
             />
           </a>
-        </div>
+        </GsapFadeIn>
       </div>
     </div>
   );

--- a/components/ui/GsapFadeIn.tsx
+++ b/components/ui/GsapFadeIn.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useRef, useEffect } from "react";
+import { gsap } from "gsap";
+import { cn } from "@/lib/utils";
+
+const GsapFadeIn = ({
+  children,
+  className,
+  from = { opacity: 0, y: 20 },
+  to = { opacity: 1, y: 0, duration: 1 },
+}: {
+  children: React.ReactNode;
+  className?: string;
+  from?: gsap.TweenVars;
+  to?: gsap.TweenVars;
+}) => {
+  const el = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      if (el.current) {
+        gsap.fromTo(el.current, from, to);
+      }
+    }, el);
+    return () => ctx.revert();
+  }, [from, to]);
+
+  return (
+    <div ref={el} className={cn(className)}>
+      {children}
+    </div>
+  );
+};
+
+export default GsapFadeIn;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-gtm-module": "^2.0.11",
     "react-icons": "^5.4.0",
     "react-lottie": "^1.2.4",
+    "gsap": "^3.12.2",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.163.0",


### PR DESCRIPTION
## Summary
- integrate the GSAP animation library
- create a reusable `GsapFadeIn` component
- animate the Hero section with GSAP
- document GSAP usage in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656fd3a914832b8b059520097c984a